### PR TITLE
Transitioning app-nettle-test from lib-newlib to lib-musl

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -4,4 +4,4 @@ config APPLIBNETTLETEST_DEPENDENCIES
 	default y
 	select LIBNETTLE
 	select LIBNETTLE_TEST
-	select LIBNEWLIBC
+	select LIBMUSL

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UK_ROOT ?= $(PWD)/../../unikraft
 UK_LIBS ?= $(PWD)/../../libs
-LIBS := $(UK_LIBS)/lib-nettle:$(UK_LIBS)/lib-newlib
+LIBS := $(UK_LIBS)/lib-nettle:$(UK_LIBS)/lib-musl
 
 all:
 	@$(MAKE) -C $(UK_ROOT) A=$(PWD) L=$(LIBS)


### PR DESCRIPTION
Pepes #1 @razvand @StefanJum  
Changes to Makefile and Config.uk . No further changes were needed as it built without errors. When running I got stuck at the "Booting from ROM.." message so I could not provide further testing.  
